### PR TITLE
Update bot.js to handle missing pm2 processes

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -26,7 +26,7 @@ pm2.list((err, list) => {
         console.log('One or more processes are offline. Restarting...');
 
 
-        const command = 'cd /root/storagechainnode-linux/ && ./kill_port.sh && /usr/local/bin/pm2 delete all && ./main.sh';
+        const command = 'chmod +x /root/storagechainnode-linux/restart.sh && /root/storagechainnode-linux/restart.sh';
 
 
         try {

--- a/bot.js
+++ b/bot.js
@@ -22,7 +22,7 @@ pm2.list((err, list) => {
         }
     });
 
-    if (offlineProcesses.length > 0) {
+    if (offlineProcesses.length > 0 || list.length < 3) {
         console.log('One or more processes are offline. Restarting...');
 
 


### PR DESCRIPTION
Additional check to verify all three pm2 processes exist.
Change to use restart.sh script as the previous string of commands would stop executing at "pm2 delete all" if there were no processes in pm2, and never trigger the main.sh script to create the missing processes.